### PR TITLE
Handle error when running

### DIFF
--- a/examples/clap_nested/main.rs
+++ b/examples/clap_nested/main.rs
@@ -28,6 +28,5 @@ fn main() {
             println!("No subcommand matched");
             Ok(())
         })
-        .run()
-        .unwrap();
+        .run();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,7 @@
 //!             println!("No subcommand matched");
 //!             Ok(())
 //!         })
-//!         .run()
-//!         .unwrap();
+//!         .run();
 //! }
 //! ```
 //!
@@ -358,8 +357,9 @@ impl<'a, S: ?Sized, T: ?Sized> Commander<'a, S, T> {
 }
 
 impl<'a, T: ?Sized> Commander<'a, (), T> {
-    pub fn run(&self) -> Result {
+    pub fn run(&self) {
         self.run_with_args(std::env::args_os())
+            .unwrap_or_else(|e| e.exit())
     }
 
     pub fn run_with_args(

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -72,7 +72,7 @@ fn two_level_commander() {
     assert!(commander.run_with_args(&["program", "what"]).is_ok());
 
     assert_result(
-        commander.run(),
+        commander.run_with_args(std::env::args_os()),
         "error: program __VERSION__
 __AUTHOR__
 __DESC__


### PR DESCRIPTION
Handle error instead of panicking when `unwrap()` after `run()` (also happen with --help). 